### PR TITLE
fix: release response after response is handled

### DIFF
--- a/pkg/auth.go
+++ b/pkg/auth.go
@@ -3,10 +3,11 @@ package pkg
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/joomcode/errorx"
-	"github.com/valyala/fasthttp"
 	"net/http"
 	"net/url"
+
+	"github.com/joomcode/errorx"
+	"github.com/valyala/fasthttp"
 )
 
 // SalesforceCredentials represents the response from salesforce's /services/oauth2/token endpoint to get an access token
@@ -21,7 +22,8 @@ type SalesforceCredentials struct {
 
 // Authenticate authenticates with salesforce, storing the resulting credentials on the SalesforceUtils object
 func (s *SalesforceUtils) Authenticate() error {
-	body, statusCode, err := s.getSalesforceAccessToken()
+	body, statusCode, deferredFunc, err := s.getSalesforceAccessToken()
+	defer deferredFunc()
 	if err != nil || statusCode != 200 {
 		return errorx.Decorate(err, "error getting access token with status code: %d and body: %s", statusCode, body)
 	}
@@ -35,7 +37,7 @@ func (s *SalesforceUtils) Authenticate() error {
 }
 
 // getSalesforceAccessToken makes an http request to the salesforce api to get an access token
-func (s *SalesforceUtils) getSalesforceAccessToken() ([]byte, int, error) {
+func (s *SalesforceUtils) getSalesforceAccessToken() ([]byte, int, func(), error) {
 	req := fasthttp.AcquireRequest()
 	defer fasthttp.ReleaseRequest(req)
 	uri := s.getAuthUrl()

--- a/pkg/bulk.go
+++ b/pkg/bulk.go
@@ -46,7 +46,8 @@ func (s *SalesforceUtils) CreateBulkQueryJob(query string) (response BulkJobReco
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBody(queryBodyBytes)
-	responseBody, statusCode, requestErr := s.sendRequest(req)
+	responseBody, statusCode, deferredFunc, requestErr := s.sendRequest(req)
+	defer deferredFunc()
 	if requestErr != nil {
 		err = requestErr
 		return
@@ -69,7 +70,8 @@ func (s *SalesforceUtils) GetBulkQueryJob(queryJobID string) (response BulkJobRe
 	uri := s.getBulkQueryJobInfoUrl(queryJobID)
 	req.SetRequestURI(uri)
 	req.Header.SetMethod(http.MethodGet)
-	body, statusCode, requestErr := s.sendRequest(req)
+	body, statusCode, deferredFunc, requestErr := s.sendRequest(req)
+	defer deferredFunc()
 	if requestErr != nil {
 		err = requestErr
 		return
@@ -146,7 +148,8 @@ func (s *SalesforceUtils) ListBulkJobs() (response ListBulkJobsResponse, err err
 	uri := s.getListBulkJobsUrl()
 	req.SetRequestURI(uri)
 	req.Header.SetMethod(http.MethodGet)
-	body, statusCode, requestErr := s.sendRequest(req)
+	body, statusCode, deferredFunc, requestErr := s.sendRequest(req)
+	defer deferredFunc()
 	if requestErr != nil {
 		err = requestErr
 		return

--- a/pkg/common.go
+++ b/pkg/common.go
@@ -7,10 +7,9 @@ import (
 )
 
 // sendRequest sends a configured request, returning the body, status code, and error
-func (s *SalesforceUtils) sendRequest(req *fasthttp.Request) ([]byte, int, error) {
+func (s *SalesforceUtils) sendRequest(req *fasthttp.Request) ([]byte, int, func(), error) {
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", s.Credentials.AccessToken))
 	res := fasthttp.AcquireResponse()
-	defer fasthttp.ReleaseResponse(res)
 	err := s.FastHTTPClient.Do(req, res)
-	return res.Body(), res.StatusCode(), err
+	return res.Body(), res.StatusCode(), func() { fasthttp.ReleaseResponse(res) }, err
 }

--- a/pkg/objects.go
+++ b/pkg/objects.go
@@ -23,7 +23,8 @@ func (s *SalesforceUtils) CreateObject(typeName string, jsonBytes []byte) (respo
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBody(jsonBytes)
-	body, statusCode, requestErr := s.sendRequest(req)
+	body, statusCode, deferredFunc, requestErr := s.sendRequest(req)
+	defer deferredFunc()
 	if requestErr != nil {
 		err = requestErr
 		return
@@ -44,7 +45,8 @@ func (s *SalesforceUtils) UpdateObject(typeName, id string, jsonBytes []byte) er
 	req.Header.SetMethod(http.MethodPatch)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBody(jsonBytes)
-	body, statusCode, requestErr := s.sendRequest(req)
+	body, statusCode, deferredFunc, requestErr := s.sendRequest(req)
+	defer deferredFunc()
 	if requestErr != nil {
 		return requestErr
 	}
@@ -60,7 +62,8 @@ func (s *SalesforceUtils) DeleteObject(typeName, id string) error {
 	uri := s.getObjectIdUrl(typeName, id)
 	req.SetRequestURI(uri)
 	req.Header.SetMethod(http.MethodDelete)
-	body, statusCode, err := s.sendRequest(req)
+	body, statusCode, deferredFunc, err := s.sendRequest(req)
+	defer deferredFunc()
 	if err != nil {
 		return err
 	}
@@ -93,7 +96,8 @@ func (s *SalesforceUtils) DescribeObject(typeName string) (response DescribeObje
 	req.SetRequestURI(uri)
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.Set("Content-Type", "application/json")
-	body, statusCode, requestErr := s.sendRequest(req)
+	body, statusCode, deferredFunc, requestErr := s.sendRequest(req)
+	defer deferredFunc()
 	if requestErr != nil {
 		err = requestErr
 		return

--- a/pkg/soql.go
+++ b/pkg/soql.go
@@ -3,10 +3,11 @@ package pkg
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/joomcode/errorx"
-	"github.com/valyala/fasthttp"
 	"net/http"
 	"net/url"
+
+	"github.com/joomcode/errorx"
+	"github.com/valyala/fasthttp"
 )
 
 type SoqlResponse struct {
@@ -22,7 +23,8 @@ func (s *SalesforceUtils) ExecuteSoqlQuery(query string) (response SoqlResponse,
 	uri := s.getQueryUrl(query)
 	req.SetRequestURI(uri)
 	req.Header.SetMethod(http.MethodGet)
-	body, statusCode, requestErr := s.sendRequest(req)
+	body, statusCode, deferredFunc, requestErr := s.sendRequest(req)
+	defer deferredFunc()
 	if requestErr != nil {
 		err = requestErr
 		return
@@ -41,7 +43,8 @@ func (s *SalesforceUtils) GetNextRecords(nextRecordsUrl string) (response SoqlRe
 	uri := s.getNextRecordsUrl(nextRecordsUrl)
 	req.SetRequestURI(uri)
 	req.Header.SetMethod(http.MethodGet)
-	body, statusCode, requestErr := s.sendRequest(req)
+	body, statusCode, deferredFunc, requestErr := s.sendRequest(req)
+	defer deferredFunc()
 	if requestErr != nil {
 		err = requestErr
 		return


### PR DESCRIPTION
Sometimes the marshaller panics because of a "data changed underfoot error". This seems to be because the byte array response body is cleared after the sendRequest function executes `fasthttp.ReleaseResponse(res)`.

The commentary on the response.Body() method confirms this:

> The returned value is valid until the response is released,
> either though ReleaseResponse or your request handler returning.
> Do not store references to returned value. Make copies instead.

https://github.com/valyala/fasthttp/blob/2c8ce3b40e933669366c9519503bc8df4f1a8b8a/http.go#L339-L341