### PR TITLE
feat: implement composite and collections api

### DIFF
--- a/pkg/collections.go
+++ b/pkg/collections.go
@@ -1,0 +1,190 @@
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/joomcode/errorx"
+	"github.com/valyala/fasthttp"
+)
+
+// CollectionsRequest is used by the CollectionsCreateObjects and
+// CollectionsUpdateObjects methods when interacting with the composite
+// collections api
+type CollectionsRequest struct {
+	AllOrNone bool `json:"allOrNone"`
+	// the use of json.RawMessage here is to avoid the need to unmarshal the
+	// provided records json and remarshal it.
+	Records []json.RawMessage `json:"records"`
+}
+
+// CollectionsResponseItem is the response item for a single object in the
+// response from the collections api
+type CollectionsResponseItem struct {
+	Id      string                     `json:"id"`
+	Success bool                       `json:"success"`
+	Errors  []CollectionsResponseError `json:"errors"`
+}
+
+// CollectionsResponseError is the error response item for a single object in
+// the response from the collections api
+type CollectionsResponseError struct {
+	StatusCode string   `json:"statusCode"`
+	Message    string   `json:"message"`
+	Fields     []string `json:"fields"`
+}
+
+// CollectionsCreateObjects creates objects in salesforce using the composite
+// "collections" api. this implementation requires that you marshal your
+// objects to json yourself with an attributes field to your object to define
+// the type.
+//
+// ex:
+//
+//	{
+//	  "attributes" : {"type" : "Account"},
+//	  "Name" : "Example"
+//	  ...
+//	}
+//
+// ref: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_create.htm
+func (s *SalesforceUtils) CollectionsCreateObjects(recordsJsonBytes [][]byte) (response []CollectionsResponseItem, err error) {
+	err = validateCollectionsRequestLength(len(recordsJsonBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := jsonRecordsToCollectionsRequestJson(recordsJsonBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.doCollectionsRequest(s.getCollectionsUrl(), fasthttp.MethodPost, body)
+}
+
+// CollectionsUpdateObjects updates objects in salesforce using the composite
+// "collections" api. this implementation requires that you marshal your
+// objects to json yourself with an attributes field to your object to define
+// the type. the objects must also have an id field.
+//
+// ex:
+//
+//	{
+//	  "attributes" : {"type" : "Account"},
+//	  "id" : "001RM0000068xVCYAY",
+//	  "Name" : "Example"
+//	  ...
+//	}
+//
+// ref: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_update.htm
+func (s *SalesforceUtils) CollectionsUpdateObjects(recordsJsonBytes [][]byte) (response []CollectionsResponseItem, err error) {
+	err = validateCollectionsRequestLength(len(recordsJsonBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := jsonRecordsToCollectionsRequestJson(recordsJsonBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.doCollectionsRequest(s.getCollectionsUrl(), fasthttp.MethodPatch, body)
+}
+
+// CollectionsDeleteRequest is used by the CollectionsDeleteObjects method when
+// interacting with the composite collections api
+type CollectionsDeleteRequest struct {
+	AllOrNone bool     `json:"allOrNone"`
+	Ids       []string `json:"ids"`
+}
+
+// CollectionsDeleteObjects deletes objects in salesforce using the composite
+// "collections" api. all that is required is the IDs of the objects to delete.
+func (s *SalesforceUtils) CollectionsDeleteObjects(ids []string) (response []CollectionsResponseItem, err error) {
+	err = validateCollectionsRequestLength(len(ids))
+	if err != nil {
+		return nil, err
+	}
+	deleteUrl := s.getCollectionsDeleteUrl(ids)
+	return s.doCollectionsRequest(deleteUrl, fasthttp.MethodDelete, nil)
+}
+
+// doCollectionsRequest is a helper method for making requests to the the
+// composite collections api. the only difference between creates and updates
+// is the method, and with deletes the url requires the ids to be passed as
+// query parameters. this parameterizes the url, method, and body so each
+// method can make use of it. everything else is the same.
+func (s *SalesforceUtils) doCollectionsRequest(url string, method string, body []byte) (response []CollectionsResponseItem, err error) {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.SetRequestURI(url)
+	req.Header.SetMethod(method)
+	req.Header.Set("Content-Type", "application/json")
+	if body != nil {
+		req.SetBody(body)
+	}
+
+	body, statusCode, deferredFunc, err := s.sendRequest(req)
+	defer deferredFunc()
+	if err != nil {
+		return response, err
+	}
+	if statusCode != fasthttp.StatusOK {
+		return response, errorx.IllegalState.New("unexpected status code: %d with body: %s", statusCode, body)
+	}
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return response, errorx.IllegalState.New("failed to unmarshal response: %s", err)
+	}
+
+	// check for errors in the response and return an error if any are found so
+	// that the caller doesn't have to check the response for errors
+	for _, respItem := range response {
+		if !respItem.Success || len(respItem.Errors) > 0 {
+			// return the first error, since allOrNone is always true
+			return response, errorx.IllegalState.New("failed to update object: %s", respItem.Errors)
+		}
+	}
+
+	return response, nil
+}
+
+func jsonRecordsToCollectionsRequestJson(recordsJsonBytes [][]byte) ([]byte, error) {
+	collectionsReq := CollectionsRequest{
+		AllOrNone: true,
+	}
+	for _, recordJsonBytes := range recordsJsonBytes {
+		collectionsReq.Records = append(collectionsReq.Records, recordJsonBytes)
+	}
+
+	return json.Marshal(collectionsReq)
+}
+
+// validateCollectionsRequestLength is a simple helper method to validate the
+// length of input for any collections request. pass the length of the input.
+// salesforce collections api has a limit of 200 records per request.
+func validateCollectionsRequestLength(length int) error {
+	if length == 0 {
+		return errorx.IllegalArgument.New("input must not be empty")
+	}
+	if length > 200 {
+		return errorx.IllegalArgument.New("input must not be larger than 200")
+	}
+	return nil
+}
+
+// getDeleteUrl gets a formatted full url to the collections api for deleting.
+// builds query parameters to include each id and adds the allOrNone=true
+// parameter.
+func (s *SalesforceUtils) getCollectionsDeleteUrl(ids []string) string {
+	idsAsCommaSeparatedString := strings.Join(ids, ",")
+	queryParams := fmt.Sprintf("?allOrNone=true&ids=%s", idsAsCommaSeparatedString)
+	return fmt.Sprintf("%s%s", s.getCollectionsUrl(), queryParams)
+}
+
+// getCollectionsUrl gets a formatted full url to the collections api.
+func (s *SalesforceUtils) getCollectionsUrl() string {
+	return fmt.Sprintf("%s/services/data/v%s/composite/sobjects", s.Config.BaseUrl, s.Config.ApiVersion)
+}

--- a/pkg/composite.go
+++ b/pkg/composite.go
@@ -55,8 +55,9 @@ type CompositeSubResponse struct {
 type CompositeSubResponseBody struct {
 	Id      string `json:"id"`
 	Success bool   `json:"success"`
-	// TODO strongly type this if we figure out the possibilities
-	Errors []map[string]interface{} `json:"errors"`
+	// TODO strongly type this when we figure out the possibilities. the docs
+	// don't specify what this field is supposed to be
+	Errors []interface{} `json:"errors"`
 }
 
 // CompositeCreateObjects creates a list of objects in salesforce using the

--- a/pkg/composite.go
+++ b/pkg/composite.go
@@ -1,0 +1,211 @@
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/joomcode/errorx"
+	"github.com/valyala/fasthttp"
+)
+
+// CompositeObject is a type used for input into CreateObjects. Contains all
+// the information that the library needs to build a CompositeRequest to send
+// to salesforce
+type CompositeObject struct {
+	// SalesforceId is only used for UpdateObjects and DeleteObjects
+	SalesforceId string
+	// ReferenceId is used to correlate the response to the request
+	ReferenceId string
+	// ObjectType is the salesforce object type, e.g. "Account"
+	ObjectType string
+	// Body is the json body to send to salesforce
+	Body []byte
+}
+
+// CompositeRequest is used by the CreateObjects method when interacting with
+// the salesforce API
+//
+// ref:
+// https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/requests_composite.htm
+type CompositeRequest struct {
+	AllOrNone        bool                  `json:"allOrNone"`
+	CompositeRequest []CompositeSubRequest `json:"compositeRequest"`
+}
+
+type CompositeSubRequest struct {
+	// the use of json.RawMessage here is to avoid the need to unmarshal the
+	// body from json and remarshal it.
+	Body        json.RawMessage `json:"body"`
+	HttpHeaders interface{}     `json:"httpHeaders"`
+	Method      string          `json:"method"`
+	ReferenceId string          `json:"referenceId"`
+	Url         string          `json:"url"`
+}
+
+type CompositeResponse struct {
+	CompositeResponse []CompositeSubResponse `json:"compositeResponse"`
+}
+
+type CompositeSubResponse struct {
+	Body           CompositeSubResponseBody `json:"body"`
+	HttpStatusCode int                      `json:"httpStatusCode"`
+	ReferenceId    string                   `json:"referenceId"`
+}
+
+type CompositeSubResponseBody struct {
+	Id      string   `json:"id"`
+	Success bool     `json:"success"`
+	Errors  []string `json:"errors"`
+}
+
+func (s *SalesforceUtils) CreateObjects(objects []CompositeObject) (response CompositeResponse, err error) {
+	compositeReq := s.convertToCompositeCreateRequest(objects)
+	return s.doCompositeRequest(compositeReq)
+}
+
+func (s *SalesforceUtils) UpdateObjects(objects []CompositeObject) (response CompositeResponse, err error) {
+	compositeReq := s.convertToCompositeUpdateRequest(objects)
+	return s.doCompositeRequest(compositeReq)
+}
+
+func (s *SalesforceUtils) UpsertObjects(objects []CompositeObject) (response CompositeResponse, err error) {
+	compositeReq := s.convertToCompositeUpsertRequest(objects)
+	return s.doCompositeRequest(compositeReq)
+}
+
+func (s *SalesforceUtils) DeleteObjects(objects []CompositeObject) (response CompositeResponse, err error) {
+	compositeReq := s.convertToCompositeDeleteRequest(objects)
+	return s.doCompositeRequest(compositeReq)
+}
+
+// convertToCompositeCreateRequest converts a list of CompositeObjects intended
+// for creation into a single CompositeRequest object that can be marshalled to
+// json to send to salesforce
+func (s *SalesforceUtils) convertToCompositeCreateRequest(objects []CompositeObject) CompositeRequest {
+	compositeReq := CompositeRequest{
+		// always set to true, so that the api behaves transactionally.
+		AllOrNone:        true,
+		CompositeRequest: []CompositeSubRequest{},
+	}
+
+	for _, obj := range objects {
+		compositeReq.CompositeRequest = append(compositeReq.CompositeRequest, CompositeSubRequest{
+			Body:        obj.Body,
+			Method:      "POST",
+			ReferenceId: obj.ReferenceId,
+			Url:         s.getTypePath(obj.ObjectType),
+		})
+	}
+
+	return compositeReq
+}
+
+// convertToCompositeUpdateRequest converts a list of CompositeObjects intended
+// for update into a single CompositeRequest object that can be marshalled to
+// json to send to salesforce
+func (s *SalesforceUtils) convertToCompositeUpdateRequest(objects []CompositeObject) CompositeRequest {
+	compositeReq := CompositeRequest{
+		// always set to true, so that the api behaves transactionally.
+		AllOrNone:        true,
+		CompositeRequest: []CompositeSubRequest{},
+	}
+
+	for _, obj := range objects {
+		compositeReq.CompositeRequest = append(compositeReq.CompositeRequest, CompositeSubRequest{
+			Body:        obj.Body,
+			Method:      "PATCH",
+			ReferenceId: obj.ReferenceId,
+			Url:         s.getObjectIdPath(obj.ObjectType, obj.SalesforceId),
+		})
+	}
+
+	return compositeReq
+}
+
+// convertToCompositeUpsertRequest converts a list of CompositeObjects intended
+// for either a create or update into a single CompositeRequest object that can
+// be marshalled to json to send to the salesforce composite api. determines
+// update vs create based on the existence of the salesforce id
+func (s *SalesforceUtils) convertToCompositeUpsertRequest(objects []CompositeObject) CompositeRequest {
+	compositeReq := CompositeRequest{
+		// always set to true, so that the api behaves transactionally.
+		AllOrNone:        true,
+		CompositeRequest: []CompositeSubRequest{},
+	}
+
+	for _, obj := range objects {
+		if obj.SalesforceId == "" {
+			compositeReq.CompositeRequest = append(compositeReq.CompositeRequest, CompositeSubRequest{
+				Body:        obj.Body,
+				Method:      "POST",
+				ReferenceId: obj.ReferenceId,
+				Url:         s.getTypePath(obj.ObjectType),
+			})
+		} else {
+			compositeReq.CompositeRequest = append(compositeReq.CompositeRequest, CompositeSubRequest{
+				Body:        obj.Body,
+				Method:      "PATCH",
+				ReferenceId: obj.ReferenceId,
+				Url:         s.getObjectIdPath(obj.ObjectType, obj.SalesforceId),
+			})
+		}
+	}
+
+	return compositeReq
+}
+
+// convertToCompositeDeleteRequest converts a list of CompositeObjects intended
+// for deletion into a single CompositeRequest object that can be marshalled to
+// json to send to salesforce
+func (s *SalesforceUtils) convertToCompositeDeleteRequest(objects []CompositeObject) CompositeRequest {
+	compositeReq := CompositeRequest{
+		// always set to true, so that the api behaves transactionally.
+		AllOrNone:        true,
+		CompositeRequest: []CompositeSubRequest{},
+	}
+
+	for _, obj := range objects {
+		compositeReq.CompositeRequest = append(compositeReq.CompositeRequest, CompositeSubRequest{
+			Method:      "DELETE",
+			ReferenceId: obj.ReferenceId,
+			Url:         s.getObjectIdPath(obj.ObjectType, obj.SalesforceId),
+		})
+	}
+
+	return compositeReq
+}
+
+func (s *SalesforceUtils) doCompositeRequest(compositeRequest CompositeRequest) (response CompositeResponse, err error) {
+	reqBodyBytes, err := json.Marshal(compositeRequest)
+	if err != nil {
+		return response, err
+	}
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	uri := s.getCompositeUrl()
+	req.SetRequestURI(uri)
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBody(reqBodyBytes)
+
+	body, statusCode, deferredFunc, err := s.sendRequest(req)
+	defer deferredFunc()
+	if err != nil {
+		return response, err
+	}
+	if statusCode != fasthttp.StatusOK {
+		return response, errorx.IllegalState.New("unexpected status code: %d with body: %s", statusCode, body)
+	}
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return response, errorx.IllegalState.New("failed to unmarshal response: %s", err)
+	}
+
+	return response, nil
+}
+
+func (s *SalesforceUtils) getCompositeUrl() string {
+	return fmt.Sprintf("%s/services/data/v%s/composite", s.Config.BaseUrl, s.Config.ApiVersion)
+}

--- a/pkg/objects.go
+++ b/pkg/objects.go
@@ -112,20 +112,32 @@ func (s *SalesforceUtils) DescribeObject(typeName string) (response DescribeObje
 	return
 }
 
-// getDataUrl gets a formatted url to the data endpoint
-func (s *SalesforceUtils) getDataUrl() string {
-	return fmt.Sprintf("%s/services/data/v%s/sobjects", s.Config.BaseUrl, s.Config.ApiVersion)
+// getDataPath gets a formatted path to the data endpoint
+func (s *SalesforceUtils) getDataPath() string {
+	return fmt.Sprintf("/services/data/v%s/sobjects", s.Config.ApiVersion)
 }
 
+// getTypePath gets a formatted path to the endoint for a specific object type
+func (s *SalesforceUtils) getTypePath(typeName string) string {
+	return fmt.Sprintf("%s/%s", s.getDataPath(), typeName)
+}
+
+// getTypeUrl gets a formatted full url to the endoint for a specific object type
 func (s *SalesforceUtils) getTypeUrl(typeName string) string {
-	return fmt.Sprintf("%s/%s", s.getDataUrl(), typeName)
+	return fmt.Sprintf("%s%s", s.Config.BaseUrl, s.getTypePath(typeName))
 }
 
-// getObjectIdUrl gets a formatted url to the endoint for a specific object by id
+// getObjectIdUrl gets a formatted path to the endoint for a specific object by id
+func (s *SalesforceUtils) getObjectIdPath(typeName, id string) string {
+	return fmt.Sprintf("%s/%s", s.getTypePath(typeName), id)
+}
+
+// getObjectIdUrl gets a formatted full url to the endoint for a specific object by id
 func (s *SalesforceUtils) getObjectIdUrl(typeName, id string) string {
-	return fmt.Sprintf("%s/%s", s.getTypeUrl(typeName), id)
+	return fmt.Sprintf("%s%s", s.Config.BaseUrl, s.getObjectIdPath(typeName, id))
 }
 
+// getDescribeUrl gets a formatted full url to the endoint for a specific object by id
 func (s *SalesforceUtils) getDescribeUrl(typeName string) string {
 	return fmt.Sprintf("%s/describe", s.getTypeUrl(typeName))
 }


### PR DESCRIPTION
originally implemented the composite API. I ran into limitations with that endpoint and so I also implemented the collections API.

The collections API works similarly to the existing objects methods, taking in a byte array of json, the difference being that it simply requires an array of byte arrays. It requires that the user adds an "attributes" field to specify the type inside of each json object.

The composite API requires more metadata to be supplied along with the objects, so a new type was introduced as input for the composite methods to make this simple. Implemented a convenient "upsert" method that automatically determines the method that should be used based on the existence of a salesforce ID in the input.